### PR TITLE
Add volunteer program collection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export * from './models/Users';
 export * from './models/VolunteerLogs';
 export * from './models/VolunteerApplications';
 export * from './models/VolunteerEvents';
+export * from './models/VolunteerPrograms';
 export * from './models/Admins';

--- a/src/models/Users.ts
+++ b/src/models/Users.ts
@@ -32,12 +32,6 @@ const UserSchema = new mongoose.Schema<UserData>(
     profileImgUrl: { type: String },
 
     /**
-     * Contains the tags of the events (no duplicates)
-     * e.g. ['RIF', 'RFR']
-     */
-    tags: [{ type: String, required: true }],
-
-    /**
      * Contains the _ids of the events the user has signed up for
      * e.g. [
      *  '5f9f5b9b0e1c9c0b3c8b4b5a',

--- a/src/models/Users.ts
+++ b/src/models/Users.ts
@@ -44,6 +44,12 @@ const UserSchema = new mongoose.Schema<UserData>(
         ref: 'VolunteerEvents',
       },
     ],
+    programs: [
+      {
+        type: mongoose.Types.ObjectId,
+        ref: 'VolunteerPrograms',
+      },
+    ],
   },
   {
     timestamps: {

--- a/src/models/VolunteerEvents.ts
+++ b/src/models/VolunteerEvents.ts
@@ -24,7 +24,7 @@ const VolunteerEventSchema = new mongoose.Schema<VolunteerEventData>(
     /**
      * The program that this event is under, represented by a tag
      */
-    program: { type: mongoose.Schema.Types.ObjectId, ref: 'Tag' },
+    program: { type: mongoose.Schema.Types.ObjectId, ref: 'Program' },
 
     /**
      * Whether this event requires an application

--- a/src/models/VolunteerPrograms.ts
+++ b/src/models/VolunteerPrograms.ts
@@ -27,7 +27,7 @@ const VolunteerProgramSchema = new mongoose.Schema<VolunteerProgramData>(
 );
 
 const VolunteerPrograms =
-  mongoose.models.Program ||
+  mongoose.models.VolunteerProgram ||
   mongoose.model<VolunteerProgramData>('Program', VolunteerProgramSchema);
 
 export default VolunteerPrograms;

--- a/src/models/VolunteerPrograms.ts
+++ b/src/models/VolunteerPrograms.ts
@@ -1,0 +1,33 @@
+import mongoose from 'mongoose';
+import { VolunteerProgramData } from '../types/database';
+
+// ProgramSchema describes what our documents should look like in our Program collections
+const VolunteerProgramSchema = new mongoose.Schema<VolunteerProgramData>(
+  {
+    name: { type: String, required: true },
+    description: { type: String },
+    /**
+     * Contains the _ids of the events the program contains
+     * e.g. [
+     *  '5f9f5b9b0e1c9c0b3c8b4b5a',
+     *  '5f9f5b9b0e1c9c0b3c8b4b5b'
+     * ]
+     */
+    events: [
+      {
+        type: mongoose.Types.ObjectId,
+        ref: 'VolunteerEvents',
+      },
+    ],
+  },
+
+  {
+    collection: 'programs',
+  }
+);
+
+const VolunteerPrograms =
+  mongoose.models.Program ||
+  mongoose.model<VolunteerProgramData>('Program', VolunteerProgramSchema);
+
+export default VolunteerPrograms;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -25,8 +25,8 @@ export interface UserData {
     expirationDate: Date;
   };
   profileImgUrl?: string;
-  tags: string[];
   events: mongoose.Types.ObjectId[];
+  programs: mongoose.Types.ObjectId[];
 }
 
 export interface QueriedUserData extends UserData {
@@ -71,14 +71,18 @@ export interface VolunteerEventData {
   tags: mongoose.Types.ObjectId[];
 }
 
-export interface QueriedVolunteerEventData
-  extends Omit<VolunteerEventData, 'program' | 'volunteers' | 'tags'> {
+export interface QueriedVolunteerEventData extends VolunteerEventData {
   _id: mongoose.Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Contains populated users, program, tags
+export interface QueriedVolunteerEventDTO
+  extends Omit<QueriedVolunteerEventData, 'program' | 'volunteers' | 'tags'> {
   program: QueriedTagData;
   volunteers: QueriedUserData[];
   tags: QueriedTagData[];
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 export interface VolunteerEventLocation {
@@ -139,4 +143,17 @@ export interface TagData {
 
 export interface QueriedTagData extends TagData {
   _id: mongoose.Types.ObjectId;
+}
+
+// --------------------- Program ----------------------
+export interface VolunteerProgramData {
+  name: string;
+  description: string;
+  events: mongoose.Types.ObjectId[];
+}
+
+export interface QueriedVolunteerProgramData
+  extends Omit<VolunteerProgramData, 'events'> {
+  _id: mongoose.Types.ObjectId;
+  events: QueriedVolunteerEventData[];
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -35,6 +35,12 @@ export interface QueriedUserData extends UserData {
   updatedAt: Date;
 }
 
+export interface QueriedUserDTO
+  extends Omit<QueriedUserData, 'programs' | 'events'> {
+  events: QueriedVolunteerEventData;
+  programs: QueriedVolunteerProgramData;
+}
+
 export interface AdminData {
   firstName: string;
   lastName: string;
@@ -152,8 +158,11 @@ export interface VolunteerProgramData {
   events: mongoose.Types.ObjectId[];
 }
 
-export interface QueriedVolunteerProgramData
-  extends Omit<VolunteerProgramData, 'events'> {
+export interface QueriedVolunteerProgramData extends VolunteerProgramData {
   _id: mongoose.Types.ObjectId;
+}
+
+export interface QueriedVolunteerProgramDTO
+  extends Omit<VolunteerProgramData, 'events'> {
   events: QueriedVolunteerEventData[];
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -37,8 +37,8 @@ export interface QueriedUserData extends UserData {
 
 export interface QueriedUserDTO
   extends Omit<QueriedUserData, 'programs' | 'events'> {
-  events: QueriedVolunteerEventData;
-  programs: QueriedVolunteerProgramData;
+  events: QueriedVolunteerEventData[];
+  programs: QueriedVolunteerProgramData[];
 }
 
 export interface AdminData {


### PR DESCRIPTION
Add volunteer program collection and modify database.ts types for volunteer events.

Now all QueriedData types contain _id and optionally createdAt and updatedAt. All types with DTO suffixes will contain populated fields. For example, QueriedEventDTO will contain program, volunteers, and tags filled up with real data instead of just IDs. 

If everything breaks (I hope not), reset to the previous commit in this repo and regenerate fake data. 